### PR TITLE
컨트롤러 requestMapping url 변경

### DIFF
--- a/src/main/java/com/quantum/holdup/controller/InquiryController.java
+++ b/src/main/java/com/quantum/holdup/controller/InquiryController.java
@@ -16,14 +16,14 @@ import java.util.HashMap;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/inquires")
+@RequestMapping("/holdup")
 @RequiredArgsConstructor
 public class InquiryController {
 
     private final InquiryService service;
 
     // 문의글 전체조회
-    @GetMapping("/inquiry")
+    @GetMapping("/inquiries")
     public ResponseEntity<ResponseMessage> findAllInquiry(@PageableDefault Pageable pageable,
                                                          @RequestParam(value = "nickname", required = false) String nickname,
                                                          @RequestParam(value = "searchType", required = false) String searchType){
@@ -44,7 +44,7 @@ public class InquiryController {
     }
 
     // 문의글 추가
-    @PostMapping("/inquiry")
+    @PostMapping("/inquiries")
     public ResponseEntity<?> createInquiry(@RequestBody CreateInquiryDTO inquiryInfo) {
 
         return ResponseEntity.ok()
@@ -55,7 +55,7 @@ public class InquiryController {
     }
 
     // 문의글 수정
-    @PutMapping("/{id}")
+    @PutMapping("/inquiries/{id}")
     public ResponseEntity<?> modifyPost(@PathVariable Long id, @RequestBody UpdateInquiryDTO modifyInfo) {
 
         UpdateInquiryDTO updatedPost = service.updateInquiry(id, modifyInfo);
@@ -68,7 +68,7 @@ public class InquiryController {
     }
 
     // 문의글 삭제
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/inquiries/{id}")
     public ResponseEntity<?> deletePost(@PathVariable long id) {
 
         Map<String, Object> responseMap = new HashMap<>();

--- a/src/main/java/com/quantum/holdup/controller/MemberController.java
+++ b/src/main/java/com/quantum/holdup/controller/MemberController.java
@@ -10,13 +10,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/member")
+@RequestMapping("/holdup")
 @RequiredArgsConstructor
 public class MemberController {
 
     private final MemberService service;
 
-    @GetMapping("/list")
+    @GetMapping("/members")
     public ResponseEntity<ResponseMessage> findAllMembers() {
         return ResponseEntity.ok()
                 .body(new ResponseMessage(
@@ -25,7 +25,7 @@ public class MemberController {
                 ));
     }
 
-    @PostMapping("/signup")
+    @PostMapping("/members")
     public ResponseEntity<?> createMember(@RequestBody CreateMemberDTO memberInfo) {
         return ResponseEntity.ok()
                 .body(new ResponseMessage(

--- a/src/main/java/com/quantum/holdup/controller/ReportController.java
+++ b/src/main/java/com/quantum/holdup/controller/ReportController.java
@@ -19,7 +19,7 @@ import java.util.Map;
 
 
 @RestController
-@RequestMapping("/reports")
+@RequestMapping("/holdup")
 @RequiredArgsConstructor
 public class ReportController {
 
@@ -27,7 +27,7 @@ public class ReportController {
     private final CommentService commentService;
 
     // 신고글 전체조회
-    @GetMapping("/report")
+    @GetMapping("/reports")
     public ResponseEntity<ResponseMessage> findAllReport(@PageableDefault Pageable pageable,
                                                          @RequestParam(value = "nickname", required = false) String nickname,
                                                          @RequestParam(value = "searchType", required = false) String searchType) {
@@ -48,7 +48,7 @@ public class ReportController {
     }
 
     // 신고글 추가
-    @PostMapping("/report")
+    @PostMapping("/reports")
     public ResponseEntity<?> createReport(@RequestBody CreateReportDTO reportInfo) {
         return ResponseEntity.ok()
                 .body(new ResponseMessage(
@@ -58,7 +58,7 @@ public class ReportController {
     }
 
     // 신고글 단건 조회
-    @GetMapping("/{id}")
+    @GetMapping("/reports/{id}")
     public ResponseEntity<ResponseMessage> findReportById(@PathVariable long id) {
 
         ReportDTO reports = service.findReportById(id);
@@ -71,7 +71,7 @@ public class ReportController {
     }
 
     // 신고글 수정
-    @PutMapping("/{id}")
+    @PutMapping("/reports/{id}")
     public ResponseEntity<?> modifyPost(@PathVariable Long id, @RequestBody UpdateReportDTO modifyInfo) {
 
         UpdateReportDTO updatedPost = service.updateReport(id, modifyInfo);
@@ -84,7 +84,7 @@ public class ReportController {
     }
 
     // 신고글 삭제
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/reports/{id}")
     public ResponseEntity<?> deletePost(@PathVariable long id) {
 
         Map<String, Object> responseMap = new HashMap<>();
@@ -109,7 +109,7 @@ public class ReportController {
     }
 
     // 댓글 추가
-    @PostMapping("/comment")
+    @PostMapping("/reports/{id}/comment")
     public ResponseEntity<?> createComment(@RequestBody CommentDTO commentInfo) {
         return ResponseEntity.ok()
                 .body(new ResponseMessage(

--- a/src/main/java/com/quantum/holdup/controller/ReservationController.java
+++ b/src/main/java/com/quantum/holdup/controller/ReservationController.java
@@ -9,12 +9,12 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/reservations")
+@RequestMapping("/holdup")
 public class ReservationController {
 
     private final ReservationService service;
 
-    @PostMapping("/{spaceId}")
+    @PostMapping("/reservations/{spaceId}")
     public ResponseEntity<?> createReservation(@PathVariable long spaceId, @RequestBody CreateReservationDTO reservationInfo) {
         return ResponseEntity.ok()
                 .body(new ResponseMessage(

--- a/src/main/java/com/quantum/holdup/controller/ReviewController.java
+++ b/src/main/java/com/quantum/holdup/controller/ReviewController.java
@@ -16,14 +16,14 @@ import java.util.HashMap;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/reviews")
+@RequestMapping("/holdup")
 @RequiredArgsConstructor
 public class ReviewController {
 
     private final ReviewService service;
     private final CommentService commentService;
 
-    @GetMapping("/review")
+    @GetMapping("/reviews")
     public ResponseEntity<ResponseMessage> findAllReview(@PageableDefault Pageable pageable){
 
         return ResponseEntity.ok()
@@ -34,7 +34,7 @@ public class ReviewController {
     }
 
     // 리뷰글 추가
-    @PostMapping("/review")
+    @PostMapping("/reviews")
     public ResponseEntity<?> createReview(@RequestBody CreateReviewDTO createReviewDTO) {
 
         return ResponseEntity.ok()
@@ -45,7 +45,7 @@ public class ReviewController {
     }
 
     // 리뷰글 수정
-    @PutMapping("/{id}")
+    @PutMapping("/reviews/{id}")
     public ResponseEntity<?> modifyReview(@PathVariable Long id, @RequestBody UpdateReviewDTO modifyInfo) {
 
         UpdateReviewDTO updatedPost = service.updateReview(id, modifyInfo);
@@ -57,7 +57,7 @@ public class ReviewController {
                 ));
     }
 
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/reviews/{id}")
     public ResponseEntity<?> deleteReview(@PathVariable long id) {
 
         Map<String, Object> responseMap = new HashMap<>();
@@ -82,7 +82,7 @@ public class ReviewController {
     }
 
     // 댓글 추가
-    @PostMapping("/comment")
+    @PostMapping("/reviews/{id}/comment")
     public ResponseEntity<?> createComment(@RequestBody CommentDTO commentInfo) {
         return ResponseEntity.ok()
                 .body(new ResponseMessage(

--- a/src/main/java/com/quantum/holdup/controller/SpaceController.java
+++ b/src/main/java/com/quantum/holdup/controller/SpaceController.java
@@ -15,14 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/spaces")
+@RequestMapping("/holdup")
 public class SpaceController {
 
     private static final Logger log = LoggerFactory.getLogger(SpaceController.class);
     private final SpaceService service;
 
     @Operation(summary = "공간 등록")
-    @PostMapping("/createSpace")
+    @PostMapping("/spaces")
     public ResponseEntity<?> createSpace(@RequestBody CreateSpaceDTO spaceInfo) {
         return ResponseEntity.ok()
                 .body(new ResponseMessage(


### PR DESCRIPTION
컨트롤러 클래스 단위의 리퀘스트 매핑 url을holdup으로 통일하였습니다.
추가적으로 각 컨트롤러마다 복수형으로 변경, 내용 추가등의 변경사항이 있으니
각자의 기능에서 사용할 컨트롤러의 변경사항을 잘 확인해주시기 바랍니다!   